### PR TITLE
testRemoveByItemPositive fixed

### DIFF
--- a/src/test/java/core/basesyntax/MyLinkedListTest.java
+++ b/src/test/java/core/basesyntax/MyLinkedListTest.java
@@ -263,8 +263,8 @@ public class MyLinkedListTest {
         myLinkedList.add(THIRD_ITEM);
 
         boolean isFirstRemoveActual = myLinkedList.remove(FIRST_ITEM);
-        boolean isNullRemoveActual = myLinkedList.remove(NULL_ITEM);
         boolean isThirdRemoveActual = myLinkedList.remove(THIRD_ITEM);
+        boolean isNullRemoveActual = myLinkedList.remove(NULL_ITEM);
         boolean isNextFirstRemoveActual = myLinkedList.remove(FIRST_ITEM);
 
         Assert.assertTrue("Test failed! Result after removing should be true",


### PR DESCRIPTION
Изменен порядок удаления елементов в тесте. Смысл изменений - попытаться удалить елемент по значению, ПЕРЕД которым в листе находится элемент с null-значением. Теперь при неверной организации сравнения будет вылетать NPE, а то тесты пропускают код такого плана (tempEntry.element не проверен на null):
```
    @Override
    public boolean remove(T t) {
        Entry<T> tempEntry = first;
        for (int i = 0; i < size; i++) {
            if (tempEntry.element == t || tempEntry.element.equals(t)) {
                remove(i);
                return true;
            }
            tempEntry = tempEntry.next;
        }
        return false;
    }
```